### PR TITLE
Add To Family feature and drop down subject menu in blog posts

### DIFF
--- a/AncestorRecords/src/main/java/com/uncc/ticket/controller/PersonController.java
+++ b/AncestorRecords/src/main/java/com/uncc/ticket/controller/PersonController.java
@@ -32,8 +32,12 @@ public class PersonController {
     }
 
     @RequestMapping(value = "/search/searchResults", method = RequestMethod.GET)
-    public String showSearchResults(Model model) {
-        model.addAttribute("persons", personService.getAllPersons()); //change this
+    public String showSearchResults(Model model, Principal principal) {
+        UsersEntity user = usersService.findByEmail(principal.getName());
+        PersonEntity person = user.getPerson();
+        model.addAttribute("relation", new RelationEntity(person,person,"unknown"));
+        model.addAttribute("persons", personService.getAllPersons());
+
         return "search/searchResult";
     }
 
@@ -49,16 +53,16 @@ public class PersonController {
         return "redirect:/";
     }
 
-    @RequestMapping(value = "/persons/family/{id}", method = RequestMethod.GET)
-    public String addRelation(Model model,@PathVariable("id") Long id, Principal principal) {
-        PersonEntity person = usersService.findByEmail(principal.getName()).getPerson();
-        RelationEntity r= new RelationEntity(person,personService.findById(id),"UNKNOWN");
+    //Sets relation
+    @RequestMapping(value = "/persons/family/{id}", method = RequestMethod.POST)
+    public String addRelation(Model model, @ModelAttribute(name = "relation") @Valid RelationEntity Relation, @PathVariable("id") Long id, @RequestParam("relationType") String relationType, @RequestParam("otherPerson") PersonEntity otherPerson, Principal principal) {
+        System.out.println("Setting Relation...");
+        PersonEntity person1 = usersService.findByEmail(principal.getName()).getPerson();
+        System.out.println("P1: " + person1.getName());
+        PersonEntity person2 = otherPerson;
+        System.out.println("P2: " + person2.getName());
+        RelationEntity r= new RelationEntity(person1,person2, relationType);
         relationService.storeRelation(r);
-        if(person.getFollowing()==null){
-            person.setFollowing(new ArrayList<PersonEntity>());
-        }
-        person.addFollowing(personService.findById(id));
-        personService.storePerson(person);
         return "redirect:/";
     }
 

--- a/AncestorRecords/src/main/java/com/uncc/ticket/model/RelationEntity.java
+++ b/AncestorRecords/src/main/java/com/uncc/ticket/model/RelationEntity.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.NotBlank;
 public class RelationEntity {
 
     @EmbeddedId
-    private RelationId id;
+    private RelationId Rid;
     @NotBlank
     private String relationType;
 
@@ -22,16 +22,18 @@ public class RelationEntity {
     }
 
     public RelationEntity(PersonEntity person1, PersonEntity person2, @NotBlank String relationType) {
-        this.id = new RelationId(person1,person2);
+        this.Rid = new RelationId(person1,person2);
+        System.out.println(Rid);
         this.relationType = relationType;
     }
 
-    public RelationId getId() {
-        return id;
+    public RelationId getRId() {
+        return Rid;
     }
 
-    public void setId(RelationId id) {
-        this.id = id;
+    public void setRId(RelationId id) {
+        System.out.println("CHANGED RID");
+        this.Rid = id;
     }
 
     public String getRelationType() {

--- a/AncestorRecords/src/main/resources/templates/Blogs/storeBlog.html
+++ b/AncestorRecords/src/main/resources/templates/Blogs/storeBlog.html
@@ -59,11 +59,15 @@
 
         <ul>
 
-            <li th:each="person : ${persons}">
-                <input type="checkbox" name="subjects" th:value="${person.id}">
-                <label th:text="${person.getName()}"></label>
-            </li>
-        </ul>
+            <!-- Subject drop-down list -->
+            <button class="btn dropdown-toggle btn-primary btn-sm" data-toggle="dropdown"
+            >Subjects<span class="subjects"></span></button>
+            <ul class="dropdown-menu", style="height:40%; overflow:hidden; overflow-y:scroll;">
+                <li th:each="person : ${persons}">
+                    <input class="form-control" id=subjects type="checkbox" name="subjects" th:value="${person.id}">
+                    <label th:text="${person.getName()}"></label>
+                </li>
+            </ul>
 
         <div class="form-group row">
             <label class="col-form-label col-sm-3" for="content">Post : </label>

--- a/AncestorRecords/src/main/resources/templates/search/searchResult.html
+++ b/AncestorRecords/src/main/resources/templates/search/searchResult.html
@@ -43,7 +43,6 @@
 
 <div class="container-fluid m-0 p-4">
 
-
     <table class="table">
         <thead class="thead-light">
         <tr>
@@ -59,10 +58,41 @@
             <td th:text="${person.getMname()}"></td>
             <td th:text="${person.getLname()}"></td>
             <td>
+
                 <a class="mb-2 btn btn-success" th:href="@{/persons/follow/{id} (id=${person.getId()})}" style="width: 80px">follow</a>
 
-                <a class="mb-2 btn btn-success" th:href="@{/persons/family/{id} (id=${person.getId()})}" style="width: 150px">Add to Family</a>
+                <!-- Opens Modal -->
+                <a class="mb-2 btn btn-success" href="#" data-toggle="modal" th:data-target="'#family'+${person.getId()}" style="width: 80px">Add To Family</a>
 
+                <!-- "Add To Family" Modal -->
+                <form th:action="@{/persons/family/{id} (id=${person.getId()})}" method="post" th:object="${relation}">
+                    <input class="form-control" type="hidden" name="otherPerson" th:value="${person.getId()}">
+                    <div class="modal fade" th:id="'family'+${person.getId()}" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                        <div class="modal-dialog" role="document">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="exampleModalLabel">Add To Family:</h5>
+                                    <!-- Input Field -->
+                                    <div class="form-group row">
+                                        <label class="col-form-label col-sm-3" for="relationType">Relation : </label>
+                                        <div class="col-sm-9">
+                                            <textarea class="form-control" id="relationType" name="relationType" th:value="${relationType}" style="height: 150px;"></textarea>
+                                            <!--<div class="Validation" style="color: red" th:if="${#fields.hasErrors('relationType')}" th:errors="*{relationType}"></div> -->
+                                        </div>
+                                    </div>
+
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                        <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                    <button class="btn btn-primary form-control" type="submit">Add To Family</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
             </td>
         </tr>
         </tbody>


### PR DESCRIPTION
Add To Family button added next to users in search list. Clicking the button brings up a modal box where the user can enter in their relation to the other person. The data is saved to the server but so far has nowhere to be displayed. A drop-down list added to blog posts to allow people to scroll through the subjects. Also, I changed a variable name in RelationId to avoid conflict.